### PR TITLE
core: improve memory management safety for ResourceMonitor

### DIFF
--- a/Source/core/ResourceMonitor.h
+++ b/Source/core/ResourceMonitor.h
@@ -1,4 +1,4 @@
- /*
+/*
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
@@ -16,16 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #pragma once
 
 #include "Module.h"
+#include "NodeId.h"
 #include "Portability.h"
 #include "Singleton.h"
 #include "Thread.h"
-#include "Trace.h"
 #include "Timer.h"
-#include "NodeId.h"
+#include "Trace.h"
+#include <memory>
 
 #ifdef __WINDOWS__
 #include <winsock2.h>
@@ -85,12 +86,12 @@ namespace Core {
             }
 
         public:
-            #ifdef __LINUX__
+#ifdef __LINUX__
             uint32_t Initialize() override
             {
                 return ((Thread::Initialize() == Core::ERROR_NONE) && (_parent.Initialize() == Core::ERROR_NONE) ? Core::ERROR_NONE : Core::ERROR_UNAVAILABLE);
             }
-            #endif
+#endif
             uint32_t Worker() override
             {
                 return (_parent.Worker());
@@ -122,25 +123,25 @@ namespace Core {
             , _monitorRuns(0)
             , _name(_T("Monitor::") + ClassNameOnly(typeid(RESOURCE).name()).Text())
             , _watchDog(1024 * 512, _name.c_str())
-            #ifdef __WINDOWS__
+#ifdef __WINDOWS__
             , _action(WSACreateEvent())
-            #else
+#else
             , _descriptorArrayLength(RESOURCE_SLOTS)
             , _descriptorArray(static_cast<struct pollfd*>(::malloc(sizeof(::pollfd) * (RESOURCE_SLOTS + 1))))
             , _signalDescriptor(-1)
-            #endif
+#endif
         {
         }
 
         ~ResourceMonitorType()
         {
-            #ifdef __DEBUG__
+#ifdef __DEBUG__
             // All resources should be gone !!!
             for (const auto& resource : _resources) {
                 TRACE_L1("Resource name: %s", typeid(resource).name());
                 ASSERT(resource == nullptr);
             }
-            #endif
+#endif
 
             if (_monitor != nullptr) {
 
@@ -154,18 +155,18 @@ namespace Core {
 
                 _adminLock.Unlock();
 
-                delete _monitor;
+                _monitor.reset();
             }
 
-            #ifdef __LINUX__
+#ifdef __LINUX__
             ::free(_descriptorArray);
             if (_signalDescriptor != -1) {
                 ::close(_signalDescriptor);
             }
-            #endif
-            #ifdef __WINDOWS__
+#endif
+#ifdef __WINDOWS__
             WSACloseEvent(_action);
-            #endif
+#endif
         }
 
     public:
@@ -179,42 +180,45 @@ namespace Core {
         }
         thread_id Id() const
         {
-            return (_monitor != nullptr ? _monitor->Id() : 0);
+            return (_monitor ? _monitor->Id() : 0);
         }
-        uint32_t Count() const 
+        uint32_t Count() const
         {
             return (static_cast<uint32_t>(_resources.size()));
         }
-        bool Info (const uint32_t position, Metadata& info) const
+        bool Info(const uint32_t position, Metadata& info) const
         {
             uint32_t count = position;
 
             _adminLock.Lock();
 
             typename Resources::const_iterator index(_resources.cbegin());
-            while ( (count != 0) && (index != _resources.cend()) ) { count--; index++; }
+            while ((count != 0) && (index != _resources.cend())) {
+                count--;
+                index++;
+            }
 
             bool found = (index != _resources.cend());
 
             if (found == true) {
                 info.descriptor = (*index)->Descriptor();
-                info.classname  = typeid(*(*index)).name();
+                info.classname = typeid(*(*index)).name();
 
-                #ifdef __LINUX__
+#ifdef __LINUX__
                 info.monitor = _descriptorArray[position + 1].events;
-                info.events  = _descriptorArray[position + 1].revents;
+                info.events = _descriptorArray[position + 1].revents;
 
                 char procfn[64];
                 snprintf(procfn, sizeof(procfn), "/proc/self/fd/%d", info.descriptor);
 
                 size_t len = readlink(procfn, info.filename, sizeof(info.filename) - 1);
                 info.filename[len] = '\0';
-                #endif
-                #ifdef __WINDOWS__
+#endif
+#ifdef __WINDOWS__
                 info.monitor = 0;
-                info.events  = 0;
+                info.events = 0;
                 info.filename[0] = '\0';
-                #endif
+#endif
             }
 
             _adminLock.Unlock();
@@ -231,8 +235,8 @@ namespace Core {
             }
 
             if (_resources.size() == 1) {
-                if (_monitor == nullptr) {
-                    _monitor = new MonitorWorker(*this);
+                if (!_monitor) {
+                    _monitor.reset(new MonitorWorker(*this));
                     _monitorRuns = 0;
                     // Wait till we are at least initialized
                     _monitor->Wait(Thread::BLOCKED | Thread::STOPPED);
@@ -261,33 +265,33 @@ namespace Core {
         }
         inline void Break()
         {
-            ASSERT(_monitor != nullptr);
+            ASSERT(_monitor);
 
-            #ifdef __APPLE__
+#ifdef __APPLE__
             int data = 0;
             ::sendto(_signalDescriptor,
-                    & data,
+                &data,
                 sizeof(data), 0,
                 static_cast<const NodeId&>(_signalNode),
                 _signalNode.Size());
-            #elif defined(__LINUX__)
+#elif defined(__LINUX__)
             _monitor->Signal(SIGUSR2);
-            #elif defined(__WINDOWS__)
+#elif defined(__WINDOWS__)
             ::WSASetEvent(_action);
-            #endif
+#endif
         };
 
     private:
         IS_MEMBER_AVAILABLE(Arm, hasArm);
 
-        template <typename TYPE=WATCHDOG>
+        template <typename TYPE = WATCHDOG>
         inline typename Core::TypeTraits::enable_if<hasArm<TYPE, void>::value, void>::type
         Arm()
         {
             _watchDog.Arm();
         }
 
-        template <typename TYPE=WATCHDOG>
+        template <typename TYPE = WATCHDOG>
         inline typename Core::TypeTraits::enable_if<!hasArm<TYPE, void>::value, void>::type
         Arm()
         {
@@ -295,14 +299,14 @@ namespace Core {
 
         IS_MEMBER_AVAILABLE(Reset, hasReset);
 
-        template <typename TYPE=WATCHDOG>
+        template <typename TYPE = WATCHDOG>
         inline typename Core::TypeTraits::enable_if<hasReset<TYPE, void>::value, void>::type
         Reset()
         {
             _watchDog.Reset();
         }
 
-        template <typename TYPE=WATCHDOG>
+        template <typename TYPE = WATCHDOG>
         inline typename Core::TypeTraits::enable_if<!hasReset<TYPE, void>::value, void>::type
         Reset()
         {
@@ -314,8 +318,7 @@ namespace Core {
             unsigned long l_Value = 1;
             if (ioctlsocket(socket, FIONBIO, &l_Value) != 0) {
                 TRACE_L1("Error on port socket NON_BLOCKING call. Error %d", ::WSAGetLastError());
-            }
-            else {
+            } else {
                 return (true);
             }
 #endif
@@ -323,14 +326,12 @@ namespace Core {
 #ifdef __POSIX__
             if (fcntl(socket, F_SETOWN, getpid()) == -1) {
                 TRACE_L1("Setting Process ID failed. <%d>", errno);
-            }
-            else {
+            } else {
                 int flags = fcntl(socket, F_GETFL, 0) | O_NONBLOCK;
 
                 if (fcntl(socket, F_SETFL, flags) != 0) {
                     TRACE_L1("Error on port socket F_SETFL call. Error %d", errno);
-                }
-                else {
+                } else {
                     return (true);
                 }
             }
@@ -343,7 +344,7 @@ namespace Core {
 #ifdef __LINUX__
         uint32_t Initialize()
         {
-            #ifdef __APPLE__
+#ifdef __APPLE__
 
             if ((_signalDescriptor = ::socket(AF_UNIX, SOCK_DGRAM, 0)) == -1) {
                 TRACE_L1("Error on creating socket SOCKET. Error %d", errno);
@@ -352,9 +353,9 @@ namespace Core {
                 TRACE_L1("Error on etting socket to non blocking. Error %d", errno);
             } else {
                 char fileNameTemplate[] = "/tmp/ResourceMonitor.XXXXXX";
-PUSH_WARNING(DISABLE_WARNING_DEPRECATED_USE)
+                PUSH_WARNING(DISABLE_WARNING_DEPRECATED_USE)
                 char* file = mktemp(fileNameTemplate);
-POP_WARNING()
+                POP_WARNING()
                 // Do we need to find something to bind to or is it pre-destined
                 _signalNode = Core::NodeId(file);
                 if (::bind(_signalDescriptor, static_cast<const NodeId&>(_signalNode), _signalNode.Size()) != 0) {
@@ -362,7 +363,7 @@ POP_WARNING()
                 }
             }
 
-            #else
+#else
 
             sigset_t sigset;
 
@@ -379,7 +380,7 @@ POP_WARNING()
             /* Create the signalfd */
             _signalDescriptor = signalfd(-1, &sigset, SFD_CLOEXEC);
 
-            #endif
+#endif
 
             ASSERT(_signalDescriptor != -1);
 
@@ -424,8 +425,7 @@ POP_WARNING()
 
                 if ((entry == nullptr) || ((events = entry->Events()) == 0)) {
                     index = _resources.erase(index);
-                }
-                else {
+                } else {
                     _descriptorArray[filledFileDescriptors].fd = entry->Descriptor();
                     _descriptorArray[filledFileDescriptors].events = events;
                     _descriptorArray[filledFileDescriptors].revents = 0;
@@ -443,14 +443,13 @@ POP_WARNING()
 
                 if (result == -1) {
                     TRACE_L1("poll failed with error <%d>", errno);
-                }
-                else if (_descriptorArray[0].revents & POLLIN) {
-                    #ifdef __APPLE__
+                } else if (_descriptorArray[0].revents & POLLIN) {
+#ifdef __APPLE__
                     int info;
-                    #else
+#else
                     /* We have a valid signal, read the info from the fd */
                     struct signalfd_siginfo info;
-                    #endif
+#endif
                     uint32_t VARIABLE_IS_NOT_USED bytes = read(_signalDescriptor, &info, sizeof(info));
                     ASSERT(bytes == sizeof(info) || bytes == 0);
                 }
@@ -487,8 +486,7 @@ POP_WARNING()
 
                     if (capacity == _resources.capacity()) {
                         index++;
-                    }
-                    else {
+                    } else {
                         // vector's capacity was changed, which means its memory was reallocated and we have to adjust the index
                         index = _resources.begin();
                         int current = fd_index;
@@ -500,8 +498,7 @@ POP_WARNING()
                         capacity = _resources.capacity();
                     }
                 }
-            }
-            else {
+            } else {
                 _monitor->Block();
                 delay = Core::infinite;
             }
@@ -510,9 +507,9 @@ POP_WARNING()
 
             return (delay);
         }
-        #endif
+#endif
 
-        #ifdef __WINDOWS__
+#ifdef __WINDOWS__
         uint32_t Worker()
         {
             uint32_t delay = 0;
@@ -580,8 +577,7 @@ POP_WARNING()
 
                     if (capacity == _resources.capacity()) {
                         index++;
-                    }
-                    else {
+                    } else {
                         uint32_t current = counter;
                         // vector's capacity was changed, which means its memory was reallocated and we have to adjust the index
                         index = _resources.begin();
@@ -602,32 +598,32 @@ POP_WARNING()
 
             return (delay);
         }
-        #endif
+#endif
 
     private:
-        MonitorWorker* _monitor;
+        std::unique_ptr<MonitorWorker> _monitor;
         mutable Core::CriticalSection _adminLock;
         Resources _resources;
         uint32_t _monitorRuns;
         string _name;
         WATCHDOG _watchDog;
 
-        #ifdef __LINUX__
+#ifdef __LINUX__
         uint32_t _descriptorArrayLength;
         struct ::pollfd* _descriptorArray;
         int _signalDescriptor;
-        #endif
+#endif
 
-        #ifdef __WINDOWS__
+#ifdef __WINDOWS__
         HANDLE _action;
-        #endif
+#endif
 
-        #ifdef __APPLE__
+#ifdef __APPLE__
         Core::NodeId _signalNode;
-        #endif
+#endif
     };
 
-    #ifdef WATCHDOG_ENABLED
+#ifdef WATCHDOG_ENABLED
     class ResourceMonitorHandler {
     public:
         ResourceMonitorHandler(ResourceMonitorHandler&& rhs) = delete;
@@ -646,10 +642,10 @@ POP_WARNING()
         }
     };
 
-    using ResourceMonitorBase = ResourceMonitorType<IResource, WatchDogType<ResourceMonitorHandler>, 0, 32> ;
-    #else
+    using ResourceMonitorBase = ResourceMonitorType<IResource, WatchDogType<ResourceMonitorHandler>, 0, 32>;
+#else
     using ResourceMonitorBase = ResourceMonitorType<IResource, Void, 0, 32>;
-    #endif
+#endif
 
     class EXTERNAL ResourceMonitor : public ResourceMonitorBase {
     private:


### PR DESCRIPTION
draft pr of course.

in this case, there are more changes than strictly necessary because the file was so out of whack vs clang format standards. need to check that we're running clang format correctly. we can validate whether fixing up whole file formatting is good / bad

on-behalf-of: @permanence-ai <github-ai@permanence.ai>